### PR TITLE
Fixed header problem

### DIFF
--- a/css/latex.css
+++ b/css/latex.css
@@ -213,6 +213,10 @@ p code, li code {
 
 
 /*下面是自动编号，初始化计数器。使用多级编号，编号后加空格模仿LaTeX */
+/* 首先全局进行一次reset，这样即使不添加h1标题也可以使用较低级别的标题 */
+#write{
+    counter-reset: h2 0 h3 0 h4 0 h5 0 h6 0
+}
 #write 
 
 h1 {


### PR DESCRIPTION
### Fixes #1
之前出现的直接输入较低级别的标题会出现不进行自动编号的问题，其原因在于如果不使用高级别的标题，低级别的标题的counter就不会被reset，所以首先进行一次全局各个级别标题counter的reset即可:
```css
/* 首先全局进行一次reset，这样即使不添加h1标题也可以使用较低级别的标题 */
#write{
    counter-reset: h2 0 h3 0 h4 0 h5 0 h6 0
}
```
[测试图示](https://i.loli.net/2021/05/22/ELRpgN3nfkDWJxF.png)
